### PR TITLE
profile page: user info, avatar upload, logout

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -61,7 +61,17 @@ function App() {
 						}
 					/>
 					<Route path="/gallery" element={<Gallery />} />
-					<Route path="/profile" element={<Profile />} />
+					<Route
+						path="/profile"
+						element={
+							<Profile
+								user={user}
+								setUser={setUser}
+								avatarURL={avatarURL}
+								setAvatarURL={setAvatarURL}
+							/>
+						}
+					/>
 					<Route path="/activity" element={<Activity />} />
 					<Route path="*" element={<p>Page not found :\</p>} />
 				</Routes>

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -1,11 +1,26 @@
-import { useEffect, useState } from "react";
-import { Alert, Box, Grid2, Skeleton, Typography } from "@mui/material";
+import { useEffect, useRef, useState } from "react";
+import {
+	Alert,
+	Avatar,
+	Box,
+	Button,
+	Divider,
+	Grid2,
+	Skeleton,
+	Stack,
+	Typography,
+} from "@mui/material";
+import { useNavigate } from "react-router";
 import { getFavourites, getOrCreateSubId } from "../libs/catApi";
+import { logOut } from "../libs/auth";
 
-export default function Profile() {
+export default function Profile({ user, setUser, avatarURL, setAvatarURL }) {
 	const [favourites, setFavourites] = useState([]);
 	const [loading, setLoading] = useState(true);
 	const [error, setError] = useState("");
+	const [avatarError, setAvatarError] = useState("");
+	const fileInputRef = useRef(null);
+	const navigate = useNavigate();
 
 	useEffect(() => {
 		const subId = getOrCreateSubId();
@@ -15,9 +30,7 @@ export default function Profile() {
 			return;
 		}
 		getFavourites(subId)
-			.then((data) => {
-				setFavourites(data || []);
-			})
+			.then((data) => setFavourites(data || []))
 			.catch((err) => {
 				console.error("Error fetching favourites", err);
 				setError("Unable to load favourites right now.");
@@ -25,11 +38,88 @@ export default function Profile() {
 			.finally(() => setLoading(false));
 	}, []);
 
+	const handleAvatarUpload = (e) => {
+		const file = e.target.files?.[0];
+		if (!file) return;
+		if (!file.type.startsWith("image/")) {
+			setAvatarError("Please select an image file.");
+			return;
+		}
+		setAvatarError("");
+		const reader = new FileReader();
+		reader.onload = (ev) => {
+			const dataUrl = ev.target.result;
+			localStorage.setItem("avatar", dataUrl);
+			setAvatarURL(dataUrl);
+		};
+		reader.readAsDataURL(file);
+	};
+
+	const handleLogout = async () => {
+		try {
+			await logOut();
+		} catch {
+			// guest session has no Firebase session to sign out
+		}
+		localStorage.clear();
+		setUser("");
+		setAvatarURL("");
+		navigate("/");
+	};
+
+	const displayName = user && user !== "guest" ? user : user === "guest" ? "Guest" : null;
+
 	return (
 		<section>
 			<h2>Profile</h2>
-			<Typography variant="body1" sx={{ mb: 1 }}>
-				Your saved favourites (limit 10).
+
+			<Stack direction="row" spacing={2} alignItems="center" sx={{ mb: 2 }}>
+				<Avatar
+					src={avatarURL || undefined}
+					alt={displayName || "avatar"}
+					sx={{ width: 72, height: 72, fontSize: 32 }}>
+					{!avatarURL && displayName ? displayName[0].toUpperCase() : null}
+				</Avatar>
+				<Box>
+					{displayName && (
+						<Typography variant="h6">{displayName}</Typography>
+					)}
+					<Stack direction="row" spacing={1} sx={{ mt: 0.5 }}>
+						<Button
+							size="small"
+							variant="outlined"
+							onClick={() => fileInputRef.current?.click()}>
+							Change photo
+						</Button>
+						<input
+							ref={fileInputRef}
+							type="file"
+							accept="image/*"
+							hidden
+							onChange={handleAvatarUpload}
+						/>
+						{user && (
+							<Button
+								size="small"
+								variant="outlined"
+								color="error"
+								onClick={handleLogout}>
+								Logout
+							</Button>
+						)}
+					</Stack>
+					{avatarError && (
+						<Typography variant="caption" color="error" sx={{ mt: 0.5, display: "block" }}>
+							{avatarError}
+						</Typography>
+					)}
+				</Box>
+			</Stack>
+
+			<Divider sx={{ mb: 2 }} />
+
+			<Typography variant="subtitle1" sx={{ mb: 1, fontWeight: 600 }}>
+				Favourites ({favourites.length}/10)
 			</Typography>
 			{error && (
 				<Alert severity="warning" sx={{ mb: 1 }}>


### PR DESCRIPTION
## Changes

- Profile header shows avatar and display name (email for auth users, "Guest" for guests)
- Avatar initial used as fallback when no image set
- "Change photo" button opens file picker, converts to data URL, persists in localStorage
- Logout button signs out Firebase session, clears localStorage, redirects to home
- Favourites section now shows current count (e.g. Favourites 3/10)

## Testing

1. Sign up or log in — go to Profile, confirm name and avatar show
2. Click "Change photo", pick an image — confirm avatar updates in navbar and profile
3. Refresh page — confirm uploaded avatar persists
4. Click Logout — confirm redirect to home, session cleared