### PR TITLE
polish UI: button visibility, set-as-avatar, pagination, home dashboard

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -60,7 +60,10 @@ function App() {
 							<Home user={user} setUser={setUser} setAvatarURL={setAvatarURL} />
 						}
 					/>
-					<Route path="/gallery" element={<Gallery />} />
+					<Route
+						path="/gallery"
+						element={<Gallery setAvatarURL={setAvatarURL} />}
+					/>
 					<Route path="/profile" element={<Profile />} />
 					<Route path="/activity" element={<Activity />} />
 					<Route path="*" element={<p>Page not found :\</p>} />

--- a/src/components/CatList.jsx
+++ b/src/components/CatList.jsx
@@ -42,46 +42,37 @@ export default function CatList({
 				))}
 			</ImageList>
 
-			<Box sx={{ display: "flex", gap: 1, justifyContent: "center", mt: 1.5 }}>
-				<Button
-					variant="outlined"
-					startIcon={<ArrowBackIosNewIcon />}
-					disabled={!hasPrevPage}
-					sx={{
-						minWidth: 130,
-						borderWidth: "2px",
-						backgroundColor: !hasPrevPage ? "#fff" : "#e89483",
-						color: !hasPrevPage ? "#888888" : "#fff",
-						"&:hover": {
-							borderColor: "currentColor",
+			<Box sx={{ display: "flex", gap: 1, justifyContent: "center", mt: 1.5, minHeight: 40 }}>
+				{hasPrevPage && (
+					<Button
+						variant="outlined"
+						startIcon={<ArrowBackIosNewIcon />}
+						sx={{
+							minWidth: 130,
+							borderWidth: "2px",
 							backgroundColor: "#e89483",
 							color: "#fff",
-						},
-					}}
-					onClick={() => setPage(Math.max(1, page - 1))}>
-					Previous Page
-				</Button>
-
-				<Button
-					variant="outlined"
-					endIcon={<ArrowForwardIosIcon />}
-					disabled={!hasNextPage}
-					sx={{
-						minWidth: 130,
-						borderWidth: "2px",
-						backgroundColor: !hasNextPage ? "#fff" : "#e89483",
-						color: !hasNextPage ? "#888888" : "#fff",
-						"&:hover": {
-							borderColor: "currentColor",
+							"&:hover": { borderColor: "currentColor", backgroundColor: "#d4705e", color: "#fff" },
+						}}
+						onClick={() => setPage(Math.max(1, page - 1))}>
+						Previous Page
+					</Button>
+				)}
+				{hasNextPage && (
+					<Button
+						variant="outlined"
+						endIcon={<ArrowForwardIosIcon />}
+						sx={{
+							minWidth: 130,
+							borderWidth: "2px",
 							backgroundColor: "#e89483",
 							color: "#fff",
-						},
-					}}
-					onClick={() => {
-						setPage(page + 1);
-					}}>
-					Next Page
-				</Button>
+							"&:hover": { borderColor: "currentColor", backgroundColor: "#d4705e", color: "#fff" },
+						}}
+						onClick={() => setPage(page + 1)}>
+						Next Page
+					</Button>
+				)}
 			</Box>
 		</Box>
 	);

--- a/src/components/CurrentCat.jsx
+++ b/src/components/CurrentCat.jsx
@@ -1,8 +1,9 @@
-import { Button, ImageListItem, Stack, Typography } from "@mui/material";
+import { Button, ImageListItem, Stack, Tooltip, Typography } from "@mui/material";
 import FavoriteBorderIcon from "@mui/icons-material/FavoriteBorder";
 import FavoriteIcon from "@mui/icons-material/Favorite";
 import ThumbUpAltOutlinedIcon from "@mui/icons-material/ThumbUpAltOutlined";
 import ThumbUpAltIcon from "@mui/icons-material/ThumbUpAlt";
+import AccountCircleIcon from "@mui/icons-material/AccountCircle";
 
 export default function CurrentCat({
 	currCatImage,
@@ -12,10 +13,17 @@ export default function CurrentCat({
 	isFavourite,
 	favouriteLimitReached,
 	favouriteLimit,
+	onSetAsAvatar,
 }) {
 	if (!currCatImage) {
 		return <div>No cat selected. Pick one below to like or favourite.</div>;
 	}
+
+	const inactiveStyle = {
+		borderWidth: 2,
+		backgroundColor: "#fff",
+		"&:hover": { backgroundColor: "primary.light", color: "#fff", borderWidth: 2 },
+	};
 
 	return (
 		<ImageListItem className="current-cat card" sx={{ mb: 1 }}>
@@ -23,9 +31,8 @@ export default function CurrentCat({
 				id="current-cat"
 				key={currCatImage.id}
 				src={currCatImage.url}
-				alt={
-					currCatImage.breed ? `${currCatImage.breed} cat` : "A cute cat"
-				}></img>
+				alt={currCatImage.breed ? `${currCatImage.breed} cat` : "A cute cat"}
+			/>
 			<Stack
 				direction="row"
 				spacing={1}
@@ -35,7 +42,8 @@ export default function CurrentCat({
 				<Button
 					variant={isLiked ? "contained" : "outlined"}
 					startIcon={isLiked ? <ThumbUpAltIcon /> : <ThumbUpAltOutlinedIcon />}
-					onClick={onToggleLike}>
+					onClick={onToggleLike}
+					sx={isLiked ? {} : inactiveStyle}>
 					{isLiked ? "Unlike" : "Like"}
 				</Button>
 				<Button
@@ -43,9 +51,21 @@ export default function CurrentCat({
 					color={favouriteLimitReached && !isFavourite ? "secondary" : "primary"}
 					startIcon={isFavourite ? <FavoriteIcon /> : <FavoriteBorderIcon />}
 					onClick={onToggleFavourite}
-					disabled={favouriteLimitReached && !isFavourite}>
+					disabled={favouriteLimitReached && !isFavourite}
+					sx={isFavourite ? {} : inactiveStyle}>
 					{isFavourite ? "Remove Favourite" : "Add Favourite"}
 				</Button>
+				{onSetAsAvatar && (
+					<Tooltip title="Set this cat as your profile picture">
+						<Button
+							variant="outlined"
+							startIcon={<AccountCircleIcon />}
+							onClick={onSetAsAvatar}
+							sx={inactiveStyle}>
+							Set as Avatar
+						</Button>
+					</Tooltip>
+				)}
 			</Stack>
 			{favouriteLimitReached && !isFavourite && (
 				<Typography variant="caption" color="text.secondary">

--- a/src/pages/Gallery.jsx
+++ b/src/pages/Gallery.jsx
@@ -14,7 +14,7 @@ import {
 import { Alert, Box, Grid2, Skeleton } from "@mui/material";
 import SortFilterBar from "../components/SortFilterBar";
 
-export default function Gallery() {
+export default function Gallery({ setAvatarURL }) {
 	const [catImages, setCatImages] = useState([]);
 	const [currCatImage, setCurrCatImage] = useState("");
 	const [catsPerPage, setCatsPerPage] = useState(20);
@@ -204,6 +204,14 @@ export default function Gallery() {
 				isFavourite={currCatImage ? isFavourite(currCatImage.id) : false}
 				favouriteLimitReached={favouriteLimitReached}
 				favouriteLimit={favouriteLimit}
+				onSetAsAvatar={
+					setAvatarURL
+						? () => {
+								localStorage.setItem("avatar", currCatImage.url);
+								setAvatarURL(currCatImage.url);
+							}
+						: null
+				}
 			/>
 			<SortFilterBar
 				catsPerPage={catsPerPage}

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,6 +1,15 @@
-import { Button } from "@mui/material";
+import { Box, Button, Card, CardActionArea, CardContent, Grid2, Typography } from "@mui/material";
+import CollectionsIcon from "@mui/icons-material/Collections";
+import PersonIcon from "@mui/icons-material/Person";
+import FavoriteIcon from "@mui/icons-material/Favorite";
 import Form from "../components/Form";
 import { NavLink } from "react-router";
+
+const quickLinks = [
+	{ label: "Gallery", description: "Browse and like cats", icon: <CollectionsIcon fontSize="large" />, to: "/gallery" },
+	{ label: "Profile", description: "Your favourites", icon: <FavoriteIcon fontSize="large" />, to: "/profile" },
+	{ label: "Activity", description: "Cats you've liked", icon: <PersonIcon fontSize="large" />, to: "/activity" },
+];
 
 export default function Home({ user, setUser, setAvatarURL }) {
 	return (
@@ -10,20 +19,30 @@ export default function Home({ user, setUser, setAvatarURL }) {
 				<p>Discover adorable cat images from around the world.</p>
 				{user ? (
 					<>
-						<p>Great to see you again {user}!</p>
-						<NavLink to="/gallery">
-							<Button
-								variant="contained"
-								color="primary"
-								sx={{ ":hover": { backgroundColor: "#A9B5DF" } }}>
-								Go to Gallery
-							</Button>
-						</NavLink>
+						<Typography variant="body1" sx={{ mb: 2 }}>
+							Good to see you, <strong>{user}</strong>!
+						</Typography>
+						<Grid2 container spacing={2} sx={{ mb: 3 }}>
+							{quickLinks.map(({ label, description, icon, to }) => (
+								<Grid2 key={label} xs={12} sm={4}>
+									<Card sx={{ height: "100%" }}>
+										<CardActionArea component={NavLink} to={to} sx={{ height: "100%" }}>
+											<CardContent sx={{ textAlign: "center" }}>
+												<Box sx={{ color: "primary.main", mb: 1 }}>{icon}</Box>
+												<Typography variant="h6">{label}</Typography>
+												<Typography variant="body2" color="text.secondary">
+													{description}
+												</Typography>
+											</CardContent>
+										</CardActionArea>
+									</Card>
+								</Grid2>
+							))}
+						</Grid2>
 						<Button
 							variant="outlined"
 							color="primary"
 							sx={{
-								margin: "10px",
 								backgroundColor: "#fff",
 								":hover": { backgroundColor: "#7886C7", color: "#2D336B" },
 							}}
@@ -36,7 +55,7 @@ export default function Home({ user, setUser, setAvatarURL }) {
 						</Button>
 					</>
 				) : (
-					<Form setUser={setUser} setAvatarURL={setAvatarURL}></Form>
+					<Form setUser={setUser} setAvatarURL={setAvatarURL} />
 				)}
 			</section>
 		</>


### PR DESCRIPTION
## Changes

**Gallery buttons**
- Like and Add Favourite buttons now have white background + 2px border in inactive state — visible without clicking

**Set as Avatar**
- New "Set as Avatar" button on the selected cat saves the image URL to localStorage as profile picture
- Updates the navbar avatar immediately

**Pagination**
- Previous/Next page buttons are hidden entirely when there is no adjacent page (no more greyed-out disabled buttons)

**Home page**
- Signed-in users now see three quick-link cards: Gallery, Profile, Activity
- Removed the "Go to Gallery" standalone button in favour of the card grid